### PR TITLE
[Debugging abraunegg#3187] Minor: gitignore consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ config.status
 autom4te.cache/
 contrib/pacman/PKGBUILD
 contrib/spec/onedrive.spec
+contrib/systemd/onedrive.service
+contrib/systemd/onedrive@.service
+
 
 # Ignore everything in the .github folder
 .github/*


### PR DESCRIPTION
This is essentially replicate of https://github.com/abraunegg/onedrive/pull/3187 for debugging why I am getting:
> # @check-spelling-bot Report
> ## :red_circle: Please review
> ### See the [:open_file_folder: files](https://github.com/abraunegg/onedrive/pull/3187/files/) view, the [:scroll:action log](https://github.com/abraunegg/onedrive/actions/runs/14159415394),  or :memo: job summary for details.
> 
> <details><summary>Unrecognized words (41)</summary>
> 
> ```
> bashisms
> capitalisation
> containerised
> customisable
> customisation
> cuz
> finalise
> finalised
> fullstop
> gzipping
> initialising
> Ioctl
> ISPs
> kinda
> Kubuntu
> logfiles
> Lubuntu
> malware
> meh
> optimisations
> preinstalled
> prioritisation
> prioritise
> prolly
> reparse
> resynchronisation
> sandboxing
> segfault
> shitload
> Slackware
> sourced
> Sourcing
> spamming
> thingies
> Thu
> uninitialised
> uninstallation
> upgradable
> utilisation
> websites
> Xubuntu
> ```
> </details>
> 
> <details><summary>To accept these unrecognized words as correct, you could run the following commands</summary>
> 
> ... in a clone of the [git@github.com:Romadelf/onedrive.git](https://github.com/Romadelf/onedrive.git) repository on the `tweak-.gitignore` branch ([:information_source: how do I use this?](https://docs.check-spelling.dev/Accepting-Suggestions)):
> 
> ``` sh
> curl -s -S -L 'https://raw.githubusercontent.com/check-spelling/check-spelling/main/apply.pl' |
> perl - 'https://github.com/abraunegg/onedrive/actions/runs/14159415394/attempts/1'
> 
> ```
> </details>

_Originally posted by @github-actions[bot] in https://github.com/abraunegg/onedrive/issues/3187#issuecomment-2764718821_

Note that as proposed by the maintainer:
> [Potentially - give that a go.](https://github.com/abraunegg/onedrive/issues/3187#issuecomment-2764762638)

I successively enabled the following two prompts before making this local PR (this was not done when the [pull request](https://github.com/abraunegg/onedrive/pull/3187) was created):

1) ![image](https://github.com/user-attachments/assets/f8cbe896-89a0-44f0-9195-b0e909062e4b)

2) ![image](https://github.com/user-attachments/assets/3685b413-4266-4467-a6c6-f02bfe93a5b8)